### PR TITLE
Fix bug in "unmark" command

### DIFF
--- a/src/main/java/duke/duke/commands/UnmarkCommand.java
+++ b/src/main/java/duke/duke/commands/UnmarkCommand.java
@@ -18,7 +18,7 @@ public class UnmarkCommand extends Command {
     public void execute(Calendar calendar, Ui ui, Storage storage) throws InvalidInputException {
         try {
             Integer index = Integer.parseInt(indexToUnmark);
-            calendar.markAsDone(index);
+            calendar.markAsNotDone(index);
             ui.showTaskIncomplete(calendar.taskAtIndex(index));
         } catch (IndexOutOfBoundsException e) {
             throw new InvalidInputException(String.format(Text.TEXT_INVALID_LIST_INDEX, calendar.numOfEntries(), Integer.parseInt(indexToUnmark)));

--- a/src/main/java/duke/duke/info/task/Calendar.java
+++ b/src/main/java/duke/duke/info/task/Calendar.java
@@ -28,7 +28,7 @@ public class Calendar {
         calendar.get(indexToMark - 1).complete();
     }
 
-    public void markAsNotDone (int indexToMark) {
+    public void markAsNotDone(int indexToMark) {
         calendar.get(indexToMark - 1).incomplete();
     }
 


### PR DESCRIPTION
Previously, there was a bug where the unmark command did not mark the
job as incomplete, but instead marked the job as complete due to an
erroneous call of markAsDone() instead of markAsNotDone().

This commit changes the method call to properly reflect the action of
marking the task as incomplete.

Let's
* Fix the unmark command to properly carry out the desired functionality