### PR TITLE
Add Date functionality to Duke

### DIFF
--- a/src/main/java/duke/duke/info/task/Deadline.java
+++ b/src/main/java/duke/duke/info/task/Deadline.java
@@ -2,20 +2,17 @@ package duke.info.task;
 
 public class Deadline extends Task {
 
-    private final String date;
-
     public Deadline(String deadline, String date, boolean isComplete) {
-        super(deadline, "deadline", isComplete);
-        this.date = date;
+        super(deadline, "deadline", isComplete, date);
     }
 
     @Override
     public String saveFormat() {
-        return super.saveFormat() + "|" + this.date;
+        return super.saveFormat() + "|" + this.getDateString();
     }
 
     @Override
     public String toString() {
-        return String.format("[D]%s (by: %s)", super.toString(), this.date);
+        return String.format("[D]%s (by: %s)", super.toString(), this.getDateString());
     }
 }

--- a/src/main/java/duke/duke/info/task/Event.java
+++ b/src/main/java/duke/duke/info/task/Event.java
@@ -2,21 +2,17 @@ package duke.info.task;
 
 public class Event extends Task {
 
-    private final String date;
-
     public Event(String event, String date, boolean isComplete) {
-        super(event, "event", isComplete);
-        this.date = date;
+        super(event, "event", isComplete, date);
     }
 
     @Override
     public String saveFormat() {
-        return super.saveFormat() + "|" + this.date;
+        return super.saveFormat() + "|" + this.getDateString();
     }
 
     @Override
     public String toString() {
-        System.out.println(date);
-        return String.format("[E]%s (at: %s)", super.toString(), this.date);
+        return String.format("[E]%s (at: %s)", super.toString(), this.getDateString());
     }
 }

--- a/src/main/java/duke/duke/info/task/Task.java
+++ b/src/main/java/duke/duke/info/task/Task.java
@@ -1,15 +1,36 @@
 package duke.info.task;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.time.format.DateTimeFormatter;
+
 public abstract class Task {
 
     private final String action;
     private boolean isComplete;
     private final String type;
+    private String dateString;
+    private LocalDate date;
 
     Task(String action, String type, boolean isComplete) {
         this.action = action;
         this.type = type;
         this.isComplete = isComplete; // task added is not complete by default
+        this.dateString = null;
+        this.date = null;
+    }
+
+    Task(String action, String type, boolean isComplete, String dateString) {
+        this.action = action;
+        this.type = type;
+        this.isComplete = isComplete;
+        try {
+            this.date = LocalDate.parse(dateString);
+            this.dateString = null;
+        } catch (DateTimeParseException e) {
+            this.date = null;
+            this.dateString = dateString;
+        }
     }
 
     void complete() {
@@ -22,6 +43,14 @@ public abstract class Task {
 
     public String saveFormat() {
         return String.format("%s|%s|%s", this.type, this.isComplete ? "1" : "0", this.action);
+    }
+
+    public String getDateString() {
+        if (this.date != null) {
+            return this.date.format(DateTimeFormatter.ofPattern("d MMM yyyy"));
+        } else {
+            return this.dateString;
+        }
     }
 
     @Override

--- a/tasks.txt
+++ b/tasks.txt
@@ -1,3 +1,4 @@
 todo|1|3
 deadline|1|2|Sunday
-event|0|hello|Sunday
+event|1|hello|Sunday
+event|0|hello|2 Dec 2019


### PR DESCRIPTION
Currently, dates are stored merely as strings in each Task. This means
that the dates cannot be manipulated in a meaningful way and prevents
any further improvement to the date functionality (such as filtering
tasks by date)

To make the date formatting more useful, the date attribute now utilizes
the LocalDate library to parse dates. When a date is input, the Task()
constructor will attempt to parse it into a LocalDate format. If the
date cannot be parsed, it will be treated as a simple string.

Lets
* Use the LocalDate library to allow dates to be utilized more
  functionally