### PR TITLE
Add JUnit tests for Todo

### DIFF
--- a/src/main/java/duke/duke/info/task/Task.java
+++ b/src/main/java/duke/duke/info/task/Task.java
@@ -74,6 +74,22 @@ public abstract class Task {
     }
 
     /**
+     * Returns a string presentation of the action in the Task as specified by action.
+     * @return - the string representation of the action required for the task
+     */
+    public String getAction() {
+        return this.action;
+    }
+
+    /**
+     * Returns a string representation of the type of the task as specified in type
+     * @return - the string representation of the type of the task
+     */
+    public String getType() {
+        return this.type;
+    }
+
+    /**
      * Returns a string representation of the date of the task. If the date is saved as a
      * LocalDate object, it is returned as the format "d MMM yyyy". Otherwise the raw
      * dateString is returned

--- a/src/test/java/TodoTest.java
+++ b/src/test/java/TodoTest.java
@@ -1,0 +1,19 @@
+import duke.info.task.Todo;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TodoTest {
+    @Test
+    public void ConstructorTest() {
+        Todo testTodo = new Todo("Finish CS2103T Assignment", false);
+        assertEquals(testTodo.getAction(), "Finish CS2103T Assignment");
+        assertEquals(testTodo.getType(), "todo");
+    }
+
+    @Test
+    public void StringTest() {
+        Todo testTodo = new Todo("Finish CS2103T Assignment", false);
+        assertEquals(testTodo.toString(), "[T][ ] Finish CS2103T Assignment");
+    }
+}


### PR DESCRIPTION
Currently, there are no unit tests for the classes in the package. This
means that there is no confirmation that any of the classes is working
as intended, which might result in regression bugs in the future when
the code is extended.

To test the codebase, JUnit tests for Todo was added to check that the
methods in the Todo class are working as intended.

Lets
* Add preliminary JUNit tests for the Todo class